### PR TITLE
Make couch auth configurable through env vars.

### DIFF
--- a/server/config/environment/index.js
+++ b/server/config/environment/index.js
@@ -30,7 +30,10 @@ var all = {
   couch: {
     host: '',
     port: 5984,
-    auth: null,
+    auth: {
+      username: process.env.COUCH_USER,
+      password: process.env.COUCH_PASS
+    },
     forceSave: false
   }
 };

--- a/server/config/environment/index.js
+++ b/server/config/environment/index.js
@@ -30,13 +30,17 @@ var all = {
   couch: {
     host: '',
     port: 5984,
-    auth: {
-      username: process.env.COUCH_USER,
-      password: process.env.COUCH_PASS
-    },
+    auth: null,
     forceSave: false
   }
 };
+
+if (process.env.COUCH_USER && process.env.COUCH_PASS) {
+  all.couch.auth = {
+    username: process.env.COUCH_USER,
+    password: process.env.COUCH_PASS
+  };
+}
 
 // Export the config object based on the NODE_ENV
 // ==============================================

--- a/server/config/local.env.sample.js
+++ b/server/config/local.env.sample.js
@@ -6,9 +6,6 @@
 // You will need to set these on the server you deploy to.
 
 module.exports = {
-  DOMAIN:           'http://localhost:9000',
-  SESSION_SECRET:   'lmisdashboard-secret',
-
-  // Control debug level for modules using visionmedia/debug
-  DEBUG: ''
+  COUCH_USER: '',
+  COUCH_PASS: ''
 };


### PR DESCRIPTION
When we disable admin party, we just have to set the couch auth env vars on the server and restart the process.