### PR TITLE
package & docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 Lightweight dashboard for LoMIS database views
 
+## Setup
+
+0. Clone repo: `git clone https://github.com/eHealthAfrica/LMIS-Dashboard.git`
+1. Install packages: `npm install && bower install`
+2. Configure public & private variables as described below
+3. Run tests: `grunt test`
+4. Start server: `grunt serve`
+
+Dashboard is accessible at http://localhost:9000/
+
 ## Server Configuration
 
 There are 2 types of configuration options: secret and public options. Secret options can only be defined as environment
@@ -10,7 +20,7 @@ left off to use default values.
 
 ### Secret Options
 
-For development, copy the file `config/local.env.sample.js` to `config/local.env.js` and set the values of the variables.
+For development, copy the file `server/config/local.env.sample.js` to `server/config/local.env.js` and set the values of the variables.
 These variables will be exported to the environment when running `grunt serve` or `grunt test`.
 
 In production, the required variables have to be set in the environment of the node process.

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "grunt-newer": "~0.7.0",
     "grunt-ng-annotate": "^0.2.3",
     "grunt-ng-constant": "^1.0.0",
-    "grunt-node-inspector": "~0.1.5",
+    "grunt-node-inspector": ">=0.2.0",
     "grunt-nodemon": "~0.2.0",
     "grunt-open": "~0.2.3",
     "grunt-protractor-runner": "^1.1.0",


### PR DESCRIPTION
Just a couple of changes I made while setting up locally:

`npm install` fails (Ubuntu 16.4 LTS, node 4.3.1) on the package `node-pre-gyp`, which is a dependency of the pacakge `grunt-node-inspector`. Updating to a later version of the package works.

I also fixed a couple of typos in the docs, and added a `setup` section.